### PR TITLE
CI Updates

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -40,7 +40,7 @@ jobs:
           GEONAMES_USERNAME: ${{ secrets.GEONAMES_USERNAME }}
           LOG_NWS_REQUESTS: 1
           PREFIXED_IDS_SALT: ${{ secrets.PREFIXED_IDS_SALT }}
-          RAILS_MAX_THREAD: 5
+          RAILS_MAX_THREADS: 5
           REDIS_URL: ${{ secrets.REDIS_URL }}
           SIMPLE_COV_ENABLED: ${{ secrets.SIMPLE_COV_ENABLED }}
           POSTGRES_USER: ${{ secrets.POSTGRES_USER }}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,7 +14,7 @@
 #
 # See https://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 
-if ENV.fetch("SIMPLE_COV_ENABLED", 0)
+if ENV["SIMPLE_COV_ENABLED"] == "1"
   require "simplecov"
   SimpleCov.start "rails"
 end


### PR DESCRIPTION
This pull request makes two small but important fixes to the test environment configuration. It corrects an environment variable typo in the GitHub Actions workflow and ensures that code coverage is only enabled when explicitly requested.

- **CI/CD and Environment Variable Fixes:**
  * Corrected the environment variable name from `RAILS_MAX_THREAD` to `RAILS_MAX_THREADS` in the `.github/workflows/rspec.yml` file, ensuring Rails receives the correct thread configuration.
  * Updated the `spec/spec_helper.rb` file to enable SimpleCov only when `SIMPLE_COV_ENABLED` is set to `"1"`, making code coverage activation more explicit and predictable.